### PR TITLE
FIX: Convert hard-coded strings to be i18n compatible

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,7 @@
+en:
+  js:
+    login:
+      microsoft_office365:
+        name: "Office 365"
+        title: "with Office 365"
+        message: "Log in via Office 365"

--- a/plugin.rb
+++ b/plugin.rb
@@ -47,9 +47,7 @@ class Office365Authenticator < ::Auth::OAuth2Authenticator
   end
 end
 
-auth_provider title: 'with Office365',
-              enabled_setting: "office365_enabled",
-              message: 'Log in via Office365',
+auth_provider enabled_setting: "office365_enabled",
               frame_width: 920,
               frame_height: 800,
               authenticator: Office365Authenticator.new(


### PR DESCRIPTION
Bringing this plugin in line to replicate Discord and LinkedIn with regard to translation strings. I believe this small modification should cover it.

Bug reported here: https://meta.discourse.org/t/microsoft-365-oauth2-plugin-text-problems/168692